### PR TITLE
Add method for datetime_holidays features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ torchaudio
 torch_geometric>=2.0
 torchmetrics>=0.7
 tqdm
+holidays

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ torchaudio
 torch_geometric>=2.0
 torchmetrics>=0.7
 tqdm
-holidays

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ install_requires = [
 ]
 
 full_install_requires = [
+    'holidays'
     'matplotlib',
     'mpld3',
     'neptune-client>=0.14',

--- a/tsl/datasets/prototypes/mixin.py
+++ b/tsl/datasets/prototypes/mixin.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pandas as pd
 
-from . import checks
 from tsl.ops.dataframe import to_numpy
+from . import checks
 from ...typing import FrameArray
 from ...utils.python_utils import ensure_list
-import holidays
+
 
 class PandasParsingMixin:
 
@@ -106,30 +106,40 @@ class TemporalFeaturesMixin:
                                  columns=units)
         return dummies
 
-    def datetime_holidays(self, country, subdiv=None):
-        """Returns a DataFrame to indicate if Dataset timestamps are in a holiday.
+    def holidays_onehot(self, country, subdiv=None):
+        """Returns a DataFrame to indicate if dataset timestamps is holiday.
         See https://python-holidays.readthedocs.io/en/latest/
 
         Args:
-        country (str): country for which holidays have to be checked. e.g. "CH" for Switzerland.
-        subdiv (dict, optional): optional country sub-division (state, region, province, canton)
-                                 e.g. "TI" for Ticino, Sitzerland.
+            country (str): country for which holidays have to be checked, e.g.,
+                "CH" for Switzerland.
+            subdiv (dict, optional): optional country sub-division (state,
+                region, province, canton), e.g., "TI" for Ticino, Switzerland.
 
         Returns: 
-            pandas.DataFrame: df with one np.uint8 column and the same datetime index as self.
-                              It indicates if the timestamp is in a holiday or not.
+            pandas.DataFrame: DataFrame with one column ("holiday") as one-hot
+                encoding (1 if the timestamp is in a holiday, 0 otherwise).
         """
+        try:
+            import holidays
+        except ModuleNotFoundError:
+            raise RuntimeError("You should install optional dependency "
+                               "'holidays' to call 'datetime_holidays'.")
 
         years = np.unique(self.index.year.values)
         h = holidays.country_holidays(country, subdiv=subdiv, years=years)
 
         # label all the timestamps, whether holiday or not
-        out = np.zeros(len(self.index), dtype=np.uint8)
-        for i in range(len(out)):
-            if self.index[i].date() in h:
-                out[i] = 1
+        out = pd.DataFrame(0, dtype=np.uint8,
+                           index=self.index.normalize(), columns=['holiday'])
+        for date in h.keys():
+            try:
+                out.loc[[date]] = 1
+            except KeyError:
+                pass
+        out.index = self.index
 
-        return pd.DataFrame(out, index=self.index, dtype=np.uint8)
+        return out
 
 
 class MissingValuesMixin:

--- a/tsl_env.yml
+++ b/tsl_env.yml
@@ -23,3 +23,4 @@ dependencies:
       - test-tube
       - torchmetrics>=0.7
       - tqdm
+      - holidays

--- a/tsl_env.yml
+++ b/tsl_env.yml
@@ -23,4 +23,3 @@ dependencies:
       - test-tube
       - torchmetrics>=0.7
       - tqdm
-      - holidays


### PR DESCRIPTION
New method to get datetime_holidays features for any year, country (and state/region/canton) 

Uses same interface as for the other datetime features.
For the holidays calendars, it relies on the holidays package --> https://pypi.org/project/holidays/ 