### PR TITLE
add support for current torchvision & tsl versions

### DIFF
--- a/examples/forecasting/config/traffic/model/dcrnn.yaml
+++ b/examples/forecasting/config/traffic/model/dcrnn.yaml
@@ -7,8 +7,6 @@ model:
     hidden_size: 64
     ff_size: 128
     kernel_size: 2
-    root_weight: True
-    add_backward: True
     n_layers: 1
     dropout: 0
     cache_support: True

--- a/examples/forecasting/run_traffic_experiment.py
+++ b/examples/forecasting/run_traffic_experiment.py
@@ -146,7 +146,7 @@ def run_traffic(cfg: DictConfig):
     model_cls.filter_model_args_(model_kwargs)
     model_kwargs.update(cfg.model.hparams)
 
-    loss_fn = torch_metrics.MaskedMAE(compute_on_step=True)
+    loss_fn = torch_metrics.MaskedMAE()
 
     log_metrics = {
         'mae': torch_metrics.MaskedMAE(),


### PR DESCRIPTION
Main file for training a model in the forecasting experiment contained deprecated argument for a metric, as well as DCRNN contained parameters which aren't presented in its signature in current version.