### PR TITLE
fixed typo in pl.Trainer, gpus= changed to devices=

### DIFF
--- a/examples/notebooks/a_gentle_introduction_to_tsl.ipynb
+++ b/examples/notebooks/a_gentle_introduction_to_tsl.ipynb
@@ -1023,7 +1023,7 @@
     "\n",
     "trainer = pl.Trainer(max_epochs=100,\n",
     "                     logger=logger,\n",
-    "                     gpus=1 if torch.cuda.is_available() else None,\n",
+    "                     devices=1 if torch.cuda.is_available() else None,\n",
     "                     limit_train_batches=100,  # end an epoch after 100 updates\n",
     "                     callbacks=[checkpoint_callback])\n",
     "\n",


### PR DESCRIPTION
fixed a possible typo in pl.Trainer, it expects parameter _devices_  and not _gpus_

![image](https://github.com/user-attachments/assets/ee45e1ea-f86e-4917-844b-8ecae3054a07)
