### PR TITLE
fixing import error of metrics module after installing via pip

### DIFF
--- a/tsl/__init__.py
+++ b/tsl/__init__.py
@@ -6,8 +6,9 @@ data = LazyLoader('data', globals(), 'tsl.data')
 datasets = LazyLoader('datasets', globals(), 'tsl.datasets')
 nn = LazyLoader('nn', globals(), 'tsl.nn')
 engines = LazyLoader('engines', globals(), 'tsl.engines')
+metrics = LazyLoader('metrics', globals(), 'tsl.metrics')
 
-__version__ = '0.9.5'
+__version__ = '0.9.6'
 
 epsilon = 5e-8
 config = Config()
@@ -21,4 +22,5 @@ __all__ = [
     'datasets',
     'nn',
     'engines',
+    'metrics',
 ]


### PR DESCRIPTION
The "metrics" package failed to import when installed via pip.
Before the fix:
```
>>> import tsl
>>> tsl.metrics.torch.mae
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    import platform
    ^^^^^^^^^^^
AttributeError: module 'tsl' has no attribute 'metrics'
>>> tsl.torch.mae
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    import platform
    ^^^^^^^^^
AttributeError: module 'tsl' has no attribute 'torch'

```

After fix:
```
>>> tsl.metrics.torch.mae
<function mae at 0x115757600>
```