### PR TITLE
Updated deprecated pandas features: offset aliases and ffill.

### DIFF
--- a/tsl/datasets/elergone.py
+++ b/tsl/datasets/elergone.py
@@ -99,7 +99,7 @@ class Elergone(DatetimeDataset):
         tsl.logger.info('Loaded raw dataset.')
         # idx = sorted(df.index)
         # start, end = idx[0], idx[-1]
-        # idx = pd.date_range(start, end, freq='15T')
+        # idx = pd.date_range(start, end, freq='15min')
         # df = df.reindex(index=idx)
         df /= 4.  # kW -> kWh
         # drop duplicates

--- a/tsl/datasets/large_st.py
+++ b/tsl/datasets/large_st.py
@@ -88,9 +88,9 @@ class LargeST(DatetimeDataset):
             fill missing values with :obj:`0`; if :obj:`None`, do not impute
             (leave :obj:`nan`).
             (default: :obj:`"zero"`)
-        freq (str): The sampling rate used for resampling (e.g., :obj:`"15T"`
+        freq (str): The sampling rate used for resampling (e.g., :obj:`"15min"`
             for 15-minutes intervals resampling).
-            (default: :obj:`"15T"`)
+            (default: :obj:`"15min"`)
         precision (int or str): The float precision of the dataset.
             (default: :obj:`32`)
     """
@@ -111,7 +111,7 @@ class LargeST(DatetimeDataset):
                  subset: SubsetType = "CA",
                  year: Optional[Union[int, Sequence[int]]] = 2019,
                  imputation_mode: Literal["nearest", "zero", None] = "zero",
-                 freq: str = "15T",
+                 freq: str = "15min",
                  precision: Union[int, str] = 32):
         # set root path
         self.root = root
@@ -213,7 +213,7 @@ class LargeST(DatetimeDataset):
             # align to authors' preprocessing
             if self.freq is not None:
                 data_df = data_df.resample(self.freq).mean()
-                # in authors' code: data_df.resample('15T').mean().round(0)
+                # in authors' code: data_df.resample('15min').mean().round(0)
             readings.append(data_df)
 
         readings = (

--- a/tsl/datasets/metr_la.py
+++ b/tsl/datasets/metr_la.py
@@ -95,7 +95,7 @@ class MetrLA(DatetimeDataset):
         traffic_path = os.path.join(self.root_dir, 'metr_la.h5')
         df = pd.read_hdf(traffic_path)
         # add missing values (index is sorted)
-        date_range = pd.date_range(df.index[0], df.index[-1], freq='5T')
+        date_range = pd.date_range(df.index[0], df.index[-1], freq='5min')
         df = df.reindex(index=date_range)
         # load distance matrix
         path = os.path.join(self.root_dir, 'metr_la_dist.npy')

--- a/tsl/datasets/pems_bay.py
+++ b/tsl/datasets/pems_bay.py
@@ -81,7 +81,7 @@ class PemsBay(DatetimeDataset):
         traffic_path = os.path.join(self.root_dir, 'pems_bay.h5')
         df = pd.read_hdf(traffic_path)
         # add missing values (index is sorted)
-        date_range = pd.date_range(df.index[0], df.index[-1], freq='5T')
+        date_range = pd.date_range(df.index[0], df.index[-1], freq='5min')
         df = df.reindex(index=date_range)
         # load distance matrix
         path = os.path.join(self.root_dir, 'pems_bay_dist.npy')
@@ -93,7 +93,7 @@ class PemsBay(DatetimeDataset):
         mask = ~np.isnan(df.values)
         if mask_zeros:
             mask &= df.values != 0
-        df.fillna(method='ffill', axis=0, inplace=True)
+        df.ffill(axis=0, inplace=True)
         return df, dist, mask
 
     def build_distance_matrix(self, ids):

--- a/tsl/datasets/pems_benchmarks.py
+++ b/tsl/datasets/pems_benchmarks.py
@@ -58,7 +58,7 @@ class _PeMS(DatetimeDataset):
         fp.close()
         index = pd.date_range(start=self.start_date,
                               periods=len(data),
-                              freq='5T')
+                              freq='5min')
 
         df_flow = pd.DataFrame(data=data[..., 0],
                                index=index).astype('float32')


### PR DESCRIPTION
Pandas no longer supports the 'T' offset alias and the method='ffill' argument for fillna(). Fixed by changing all instances of 'T' to 'min' and the one instance of "fillna(method='ffill')" to just "ffill". 

Tested the code after and it fixed the error I encountered when trying to download the PemsBay dataset with Pandas 3. I did downgrade my pandas and made sure that these changes also worked with Pandas 2 and they did. 